### PR TITLE
Fix deskbar replicant

### DIFF
--- a/Source/App.h
+++ b/Source/App.h
@@ -6,6 +6,8 @@
 #include <Application.h>
 #include <Window.h>
 
+extern const char* kSignature;
+
 class App : public BApplication
 {
 private:

--- a/Source/ForecastDeskbarView.cpp
+++ b/Source/ForecastDeskbarView.cpp
@@ -5,6 +5,8 @@
 
 #include <Alert.h>
 #include <Bitmap.h>
+#include <Catalog.h>
+#include <IconUtils.h>
 #include <Looper.h>
 #include <MessageRunner.h>
 #include <Roster.h>
@@ -14,19 +16,33 @@
 #include "App.h"
 #include "ForecastDeskbarView.h"
 #include "ForecastView.h"
-#include "Util.h"
 
 const uint32 kUpdateForecastMessage = 'Updt';
 const float kToolTipDelay = 1000000; /*1000000ms = 1s*/
 
-
-ForecastDeskbarView::ForecastDeskbarView(BRect viewSize, ForecastView* forecastView)
+ForecastDeskbarView::ForecastDeskbarView(BRect viewSize)
 	:
 	BView(viewSize, "ForecastDeskbarView", B_FOLLOW_ALL, B_WILL_DRAW)
 {
-	fForecastView = forecastView;
+	// forecastview is only needed to get the weather icon
+	fForecastView = new ForecastView(BRect(0, 0, 0, 0));
+	AddChild(fForecastView);
 	fMessageRunner = NULL;
 }
+
+
+ForecastDeskbarView::ForecastDeskbarView(BMessage* archive)
+	:
+	BView(archive),
+	fMessageRunner(NULL)
+{
+	// fForecastView is unarchived and already added to the view hierarchy
+	fForecastView = static_cast<ForecastView*>(FindView("Weather"));
+	entry_ref appRef;
+	archive->FindRef("appLocation", &appRef);
+	SetAppLocation(appRef);
+}
+
 
 
 ForecastDeskbarView::~ForecastDeskbarView()
@@ -43,27 +59,8 @@ ForecastDeskbarView::AttachedToWindow()
 		new BMessage(kUpdateForecastMessage), kToolTipDelay, -1);
 
 	fForecastView->SetShowForecast(true);
-	AddChild(fForecastView);
 
 	AdoptParentColors();
-}
-
-extern "C" _EXPORT BView* instantiate_deskbar_item();
-
-
-BView*
-instantiate_deskbar_item()
-{
-	BMessage settings;
-	LoadSettings(settings);
-	ForecastDeskbarView* view = new ForecastDeskbarView(
-		BRect(0, 0, 16, 16), 
-		new ForecastView(BRect(0, 0, 0, 0), 
-		&settings));
-	entry_ref appRef;
-	settings.FindRef("appLocation", &appRef);
-	view->SetAppLocation(appRef);
-	return view;
 }
 
 
@@ -71,14 +68,28 @@ void
 ForecastDeskbarView::Draw(BRect drawRect)
 {
 	BView::Draw(drawRect);
-
 	SetDrawingMode(B_OP_OVER);
 		// TO-DO: Try with 
 		// SetBlendingMode(B_PIXEL_ALPHA, B_ALPHA_OVERLAY);
-	BBitmap* bitmap = fForecastView->GetWeatherIcon(static_cast<weatherIconSize>(1));
-	if (bitmap)
-		DrawBitmapAsync(bitmap, BPoint(0, 0));
+	BBitmap* icon = fForecastView->GetWeatherIcon();
+	if (icon != NULL)
+		DrawBitmap(icon, B_ORIGIN);
 	SetDrawingMode(B_OP_COPY);
+}
+
+
+status_t
+ForecastDeskbarView::Archive(BMessage* into, bool deep) const
+{
+	status_t status = BView::Archive(into, deep);
+	if (status != B_OK)
+		return status;
+	
+	status = into->AddString("add_on", kSignature);
+	if (status != B_OK)
+		return status;
+
+	return status;
 }
 
 
@@ -88,7 +99,7 @@ ForecastDeskbarView::Instantiate(BMessage* archive)
 	if (!validate_instantiation(archive, "ForecastDeskbarView"))
 		return NULL;
 
-	return reinterpret_cast<BArchivable*>(instantiate_deskbar_item());
+	return new ForecastDeskbarView(archive);
 }
 
 
@@ -136,4 +147,14 @@ void
 ForecastDeskbarView::SetAppLocation(entry_ref location)
 {
 	fAppRef = location;
+}
+
+
+extern "C" BView* instantiate_deskbar_item(float maxWidth, float maxHeight);
+
+
+BView*
+instantiate_deskbar_item(float maxWidth, float maxHeight)
+{	
+	return new ForecastDeskbarView(BRect(0, 0, maxWidth - 1, maxHeight - 1));
 }

--- a/Source/ForecastDeskbarView.h
+++ b/Source/ForecastDeskbarView.h
@@ -19,7 +19,8 @@ class ForecastDeskbarView : public BView
 {
 	
 public:
-					ForecastDeskbarView(BRect viewSize, ForecastView* forecastView);
+					ForecastDeskbarView(BRect viewSize);
+					ForecastDeskbarView(BMessage* archive);
 					~ForecastDeskbarView();
 
 	virtual void	AttachedToWindow();
@@ -30,11 +31,11 @@ public:
 						const BMessage* dragMessage);
 	virtual void	Draw(BRect drawRect);
 	virtual void	MessageReceived(BMessage* message);
+	status_t 		Archive(BMessage* into, bool deep = true) const;
 	static 			BArchivable* Instantiate(BMessage* archive);
 	void 			SetAppLocation(entry_ref location);
 
 private:
-
 	ForecastView*	fForecastView;
 	BMessageRunner*	fMessageRunner;
 	entry_ref		fAppRef;

--- a/Source/ForecastView.h
+++ b/Source/ForecastView.h
@@ -124,13 +124,10 @@ enum weatherConditions {
 //	WC_NOT_AVALIABLE,
 //};
 
-class _EXPORT ForecastView;
-
-
 class ForecastView : public BView
 {
 public:
-					ForecastView(BRect frame, BMessage* settings);
+					ForecastView(BRect frame);
 					ForecastView(BMessage* archive);
 	virtual			~ForecastView();
 
@@ -162,7 +159,7 @@ status_t			SaveState(BMessage* into, bool deep = true) const;
 	void			SetBackgroundColor(rgb_color color);
 	bool			IsDefaultColor() const;
 	bool			IsConnected() const;
-	BBitmap*		GetWeatherIcon(weatherIconSize size);
+	BBitmap*		GetWeatherIcon();
 	BBitmap* 		GetWeatherIcon(int32 condition, weatherIconSize size);
 	int32			GetCondition();
 	BString			GetStatus();

--- a/Source/MainWindow.cpp
+++ b/Source/MainWindow.cpp
@@ -46,8 +46,8 @@ MainWindow::_PrepareMenuBar(void)
 		B_TRANSLATE("Refresh"), new BMessage(kUpdateMessage), 'R'));
 	menu->AddSeparatorItem();
 	//	Remove menu item until Deskbar replicant is fixed
-	//	menu->AddItem(fReplicantMenuItem = new BMenuItem(B_TRANSLATE("Deskbar
-	//Replicant"), 		new BMessage(kToggleDeskbarReplicantMessage), 'T'));
+	menu->AddItem(fReplicantMenuItem = new BMenuItem(B_TRANSLATE("Deskbar Replicant"),
+ 		new BMessage(kToggleDeskbarReplicantMessage), 'T'));
 	menu->AddItem(new BMenuItem(B_TRANSLATE("Change location" B_UTF8_ELLIPSIS),
 		new BMessage(kCitySelectionMessage), 'L'));
 	menu->AddItem(new BMenuItem(B_TRANSLATE("Preferences" B_UTF8_ELLIPSIS),
@@ -80,14 +80,12 @@ MainWindow::MainWindow()
 
 	BMessage settings;
 	LoadSettings(settings);
-
 	if (settings.FindRect("fMainWindowRect", &fMainWindowRect) != B_OK)
 		fMainWindowRect = kDefaultMainWindowRect;
 
 	MoveTo(fMainWindowRect.LeftTop());
 
-
-	fForecastView = new ForecastView(BRect(0, 0, 100, 100), &settings);
+	fForecastView = new ForecastView(BRect(0, 0, 100, 100));
 	AddChild(fForecastView);
 	// Enable when works
 	// fShowForecastMenuItem->SetMarked(fForecastView->ShowForecast());
@@ -99,30 +97,9 @@ MainWindow::MessageReceived(BMessage* msg)
 {
 	switch (msg->what) {
 		case kUpdateCityMessage:
-		{
-
-			BString cityName;
-			int32 cityId;
-			double latitude, longitude;
-
-			msg->FindString("city", &cityName);
-			msg->FindInt32("id", &cityId);
-			msg->FindDouble("latitude", &latitude);
-			msg->FindDouble("longitude", &longitude);
-
-			if (fForecastView->CityId() != cityId) {
-				fForecastView->SetCityName(cityName);
-				fForecastView->SetCityId(cityId);
-				fForecastView->SetLatitude(latitude);
-				fForecastView->SetLongitude(longitude);
-				fForecastView->SetCondition(
-					B_TRANSLATE("Loading" B_UTF8_ELLIPSIS));
-				// forcedForecast use forecast request to retrieve full city
-				// name In the condition respond the isn't the full city name
-				fForecastView->Reload(true);
-			}
+			// forward the message there
+			fForecastView->MessageReceived(msg);
 			break;
-		}
 		case kUpdatePrefMessage:
 		{
 			int32 unit;
@@ -133,11 +110,7 @@ MainWindow::MessageReceived(BMessage* msg)
 		}
 		case kUpdateMessage:
 		{
-			if (fForecastView->IsConnected()) {
-				fForecastView->SetCondition(
-					B_TRANSLATE("Loading" B_UTF8_ELLIPSIS));
-				fForecastView->Reload();
-			}
+			fForecastView->MessageReceived(msg);
 			break;
 		}
 		case kShowForecastMessage:
@@ -187,7 +160,6 @@ MainWindow::MessageReceived(BMessage* msg)
 		case kToggleDeskbarReplicantMessage:
 		{
 			BDeskbar deskbar;
-
 			if (!deskbar.HasItem("ForecastDeskbarView")) {
 				app_info info;
 				be_roster->GetAppInfo(
@@ -253,8 +225,8 @@ void
 MainWindow::MenusBeginning()
 {
 	//	Menu item removed until Deskbar replicant is fixed
-	//	BDeskbar deskbar;
-	//	fReplicantMenuItem->SetMarked(deskbar.HasItem("ForecastDeskbarView"));
+	BDeskbar deskbar;
+	fReplicantMenuItem->SetMarked(deskbar.HasItem("ForecastDeskbarView"));
 }
 
 

--- a/Source/WSOpenMeteo.h
+++ b/Source/WSOpenMeteo.h
@@ -23,7 +23,7 @@ using namespace BPrivate::Network;
 class WSOpenMeteo : public BUrlProtocolListener
 {
 public:
-						WSOpenMeteo(BHandler* fHandler, BMallocIO* responseData, 
+						WSOpenMeteo(const BMessenger& messenger, BMallocIO* responseData, 
 							RequestType requestType);
 	virtual				~WSOpenMeteo();
 
@@ -37,7 +37,7 @@ public:
 private:
 	void				_ProcessWeatherData(bool success);
 	void				_ProcessCityData(bool success);
-	BHandler*			fHandler;
+	BMessenger			fMessenger;
 	RequestType 		fRequestType;
 	BMallocIO*			fResponseData;
 	void				SerializeBMessage(BMessage* message, BString fileName);


### PR DESCRIPTION
There were various problems which didn't let the deskbar replicant work. Most notably: the update city message was handled by the window, which isn't available when in replicant mode.
Moreover, it seems that the URL construction was wrong with certain locales.
- Cleanups and simplifications

There is still a problem that the deskbar replicant doesn't handle city changes live: you have to disable the replicant, close the app, and reenable the deskbar replicant.
Fix #83