### PR TITLE
Fix tooltip and show weather  condition correctly

### DIFF
--- a/Source/ForecastDeskbarView.h
+++ b/Source/ForecastDeskbarView.h
@@ -17,7 +17,7 @@
 
 class ForecastDeskbarView : public BView
 {
-	
+
 public:
 					ForecastDeskbarView(BRect viewSize);
 					ForecastDeskbarView(BMessage* archive);

--- a/Source/ForecastView.cpp
+++ b/Source/ForecastView.cpp
@@ -51,6 +51,7 @@ const double kDefaultLatitude = 37.45383;
 const int32 kMaxUpdateDelay = 240;
 const int32 kMaxForecastDay = 5;
 const int32 kReconnectionDelay = 5;
+int32 fSizeDeskBarIcon = 10;
 
 
 #undef B_TRANSLATION_CONTEXT
@@ -692,7 +693,7 @@ ForecastView::_LoadIcons(BBitmap* bitmap[3], uint32 type, const char* name)
 		BBitmap* largeBitmap = new BBitmap(
 			BRect(0, 0, kSizeLargeIcon - 1, kSizeLargeIcon - 1), 0, B_RGBA32);
 		BBitmap* deskbarBitmap = new BBitmap(
-			BRect(0, 0, kSizeDeskBarIcon - 1, kSizeDeskBarIcon - 1), 0,
+			BRect(0, 0, fSizeDeskBarIcon - 1, fSizeDeskBarIcon - 1), 0,
 			B_RGBA32);
 
 		status_t status = smallBitmap->InitCheck();
@@ -1287,4 +1288,10 @@ ForecastView::_NetworkConnected()
 		}
 	}
 	return false;
+}
+
+void
+ForecastView::SetDeskbarIconSize(int height)
+{
+	fSizeDeskBarIcon = height;
 }

--- a/Source/ForecastView.h
+++ b/Source/ForecastView.h
@@ -164,6 +164,7 @@ status_t			SaveState(BMessage* into, bool deep = true) const;
 	int32			GetCondition();
 	BString			GetStatus();
 	int32			Temperature();
+	void			SetDeskbarIconSize(int height);
 
 private:
 	void			_Init();

--- a/Source/MainWindow.cpp
+++ b/Source/MainWindow.cpp
@@ -46,7 +46,7 @@ MainWindow::_PrepareMenuBar(void)
 		B_TRANSLATE("Refresh"), new BMessage(kUpdateMessage), 'R'));
 	menu->AddSeparatorItem();
 	//	Remove menu item until Deskbar replicant is fixed
-	menu->AddItem(fReplicantMenuItem = new BMenuItem(B_TRANSLATE("Deskbar Replicant"),
+	menu->AddItem(fReplicantMenuItem = new BMenuItem(B_TRANSLATE("Deskbar replicant"),
  		new BMessage(kToggleDeskbarReplicantMessage), 'T'));
 	menu->AddItem(new BMenuItem(B_TRANSLATE("Change location" B_UTF8_ELLIPSIS),
 		new BMessage(kCitySelectionMessage), 'L'));

--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	x-vnd.przemub.Weather	704655087
+1	English	x-vnd.przemub.Weather	3368765232
 No network	ForecastView		No network
 OK	ForecastView		OK
 Slight rain	ForecastView		Slight rain
@@ -14,9 +14,9 @@ Preferences…	MainWindow		Preferences…
 Freezing dense drizzle	ForecastView		Freezing dense drizzle
 Use Celsius °C	PreferencesWindow		Use Celsius °C
 Heavy snow fall	ForecastView		Heavy snow fall
+Deskbar replicant	MainWindow		Deskbar replicant
 Weather (The Replicant version)	ForecastView		Weather (The Replicant version)
 Weather	System name		Weather
-Loading…	MainWindow		Loading…
 Mainly clear	ForecastView		Mainly clear
 Partly cloudy	ForecastView		Partly cloudy
 OK	PreferencesWindow		OK
@@ -33,6 +33,7 @@ Clear sky	ForecastView		Clear sky
 Moderate rain showers	ForecastView		Moderate rain showers
 Enter location: city, country, region	CitiesListSelectionWindow		Enter location: city, country, region
 Snow grains	ForecastView		Snow grains
+Temperature: %s\nCondition: %s\nLocation: %s	ForecastDeskbarView		Temperature: %s\nCondition: %s\nLocation: %s
 Slight rain showers	ForecastView		Slight rain showers
 Heavy rain	ForecastView		Heavy rain
 Light drizzle	ForecastView		Light drizzle


### PR DESCRIPTION
This PR fixes a few minor issues:
- The tooltip will show a description of the condition, not a number
- The entire tooltip is translatable (as a single string)
- Remove empty space after the icon (replicants added after Weather will have a lot of empty space in front of them)

There is a pending issue with scaling, the constant `kSizeDeskBarIcon` in `ForecastView.h` will cause the generated icon to 16x16 pixels. It can be scaled, but that makes it look blurred. The icon should be generated to the value of `maxHeight` from `instantiate_deskbar_item(float maxWidth, float maxHeight)`